### PR TITLE
Add support for auto-blade feature.

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -214,6 +214,11 @@ work correctly, the diameter of the tool must also be supplied.
 
 .. automethod:: SilhouetteDevice.set_tool_diameter
 
+Finally, for devices with an auto blade, the following function may be used to
+automatically set the blade depth.
+
+.. automethod:: SilhouetteDevice.set_depth
+
 
 Plotting
 ````````
@@ -258,6 +263,8 @@ The following exceptions may be thrown by this library.
 
 .. autoexception:: RegistrationMarkNotFoundError
 
+.. autoexception:: AutoBladeNotSupportedError
+
 
 Origins and Acknowledgements
 ````````````````````````````
@@ -275,5 +282,9 @@ Inkscape-Silhouette_). Based hints in these other codebases I managed to
 document the remaining 'unknowns' within my minimal subset of the USB protocol
 used by Silhouette Studio.
 
+I'm also greatful to derwassi_ on GitHub for reverse engineering and assisting
+with testing of the auto-blade feature.
+
 .. _Robocut: https://github.com/nosliwneb/robocut
 .. _Inkscape-Silhouette: https://github.com/fablabnbg/inkscape-silhouette
+.. _derwassi: https://github.com/derwassi

--- a/test/test_sheet.py
+++ b/test/test_sheet.py
@@ -116,3 +116,29 @@ d.set_force(d.params.tool_force_max)
 d.move_home()
 d.flush()
 input(" Lines should have been drawn at different forces. <Press Enter>")
+
+if d.params.tool_depth_min is not None:
+    print("Test 6: Auto blade depth test")
+    input("    Remove pen and install auto-blade knife, then <Press Enter>")
+    twenty_fifth = int(
+        d.params.tool_depth_min +
+        (d.params.tool_depth_max - d.params.tool_depth_min) * 0.25
+    )
+    seventy_fifth = int(
+        d.params.tool_depth_min +
+        (d.params.tool_depth_max - d.params.tool_depth_min) * 0.75
+    )
+    for depth in [
+        seventy_fifth,
+        twenty_fifth,
+        d.params.tool_depth_max,
+        d.params.tool_depth_min,
+    ]:
+        d.set_depth(depth)
+        d.flush()
+        input("    Auto blade should be set to {} <Press Enter>".format(depth))
+else:
+    print("Test 6: Auto blade depth test")
+    print("    SKIPPED (autoblade not supported for {})".format(
+        d.params.product_name,
+    ))


### PR DESCRIPTION
Adds a `set_depth` method for controlling the Auto Blade feature of some Silhouette devices.

A prerequisite for fixing mossblaser/plottie#3.

------

@derwassi would you be happy to test these changes work with your device? To do this, checkout and install this branch in a virtualenv:

```bash
$ git clone git@github.com:mossblaser/py_silhouette.git
$ cd py_silhouette
$ git checkout add-auto-blade-support
$ virtualenv -p python3 venv
$ . venv/bin/activate
$ pip install -e .
```

Print out [`test/test_sheet.pdf`](https://github.com/mossblaser/py_silhouette/raw/add-auto-blade-support/test/test_sheet.pdf) and follow the steps described in [`test/README.md`](https://github.com/mossblaser/py_silhouette/blob/add-auto-blade-support/test/README.md) which pretty much boils down to stick a pen in your machine, and run the following command and follow the prompts:

```bash
$ python test/test_sheet.py
```

If you don't have a pen and/or can't be bothered running through the full set of tests, skip the printing step and just comment out lines 33-118 in `test_sheet.py` and just the auto knife test should be run. Let me know if that test runs into any problems!

Thank you!